### PR TITLE
added new code routing

### DIFF
--- a/lib/erga/research.ex
+++ b/lib/erga/research.ex
@@ -45,7 +45,21 @@ defmodule Erga.Research do
       ** (Ecto.NoResultsError)
 
   """
-  def get_project!(code) do
+  def get_project!(id) do
+    try do
+      Repo.get!(Project, id)
+      |> Repo.preload(stakeholders: :person)
+      |> Repo.preload(:linked_resources)
+      |> Repo.preload(:external_links)
+      |> Repo.preload(:images)
+      |> Repo.preload(:title)
+      |> Repo.preload(:description)
+    rescue
+      _e in Ecto.NoResultsError -> raise ArgumentError
+    end
+  end
+
+  def get_project_by_code!(code) do
     try do
       Repo.one!(from(p in Project, where: p.project_code == ^code))
       |> Repo.preload(stakeholders: :person)

--- a/lib/erga/research.ex
+++ b/lib/erga/research.ex
@@ -6,6 +6,7 @@ defmodule Erga.Research do
 
   import Ecto.Query, warn: false
   alias Erga.Repo
+  alias Ecto.NoResultsError
 
   alias Erga.Research.{Project, LinkedResource, ExternalLink, Image, Stakeholder, TranslatedContent, ProjectTranslation}
 
@@ -44,14 +45,30 @@ defmodule Erga.Research do
       ** (Ecto.NoResultsError)
 
   """
-  def get_project!(id) do
-    Repo.get!(Project, id)
-    |> Repo.preload(stakeholders: :person)
-    |> Repo.preload(:linked_resources)
-    |> Repo.preload(:external_links)
-    |> Repo.preload(:images)
-    |> Repo.preload(:title)
-    |> Repo.preload(:description)
+  def get_project!(code) do
+    try do
+      Repo.one!(from(p in Project, where: p.project_code == ^code))
+      |> Repo.preload(stakeholders: :person)
+      |> Repo.preload(:linked_resources)
+      |> Repo.preload(:external_links)
+      |> Repo.preload(:images)
+      |> Repo.preload(:title)
+      |> Repo.preload(:description)
+    rescue
+      _e in Ecto.NoResultsError -> raise ArgumentError
+    end
+  end
+
+  @spec get_project_code(any) :: {:error, <<_::104>>} | {:ok, any}
+  def get_project_code(id) do
+    try do
+      case Repo.one(from(p in Project, select: %{code: p.project_code}, where: p.id == ^id)) do
+        %{ code: code } -> {:ok, code}
+        nil -> {:error, "nothing found"}
+      end
+    rescue
+      _e in Ecto.Query.CastError -> {:error, "nothing found"}
+    end
   end
 
   @doc """

--- a/lib/erga_web/controllers/api/project_controller.ex
+++ b/lib/erga_web/controllers/api/project_controller.ex
@@ -23,9 +23,14 @@ defmodule ErgaWeb.Api.ProjectController do
     render(conn, "list.json", projects: projects)
   end
 
-  def show(conn, %{"id" => id}) do
-    project = Research.get_project!(id)
-    render(conn, "show.json", project: project)
+  def show(conn, %{"id" => code}) do
+    try do
+      project = Research.get_project_by_code!(code)
+      render(conn, "show.json", project: project)
+    rescue
+      _e in ArgumentError ->
+          render(conn, "error.json", %{:name => "ArgumentError", :msg => "no project found for given code", :code => 404})
+    end
   end
 
   defp parse_date(date_string) do

--- a/lib/erga_web/controllers/project_controller.ex
+++ b/lib/erga_web/controllers/project_controller.ex
@@ -33,7 +33,7 @@ defmodule ErgaWeb.ProjectController do
   def show(conn, %{"id" => id, "lang" => lang}) do
       try do
         project = Research.get_project!(id)
-        render(conn, "show.json", project: project, lang: lang)
+        render(conn, "show.html", project: project, lang: lang)
       rescue
         _e in ArgumentError ->
           conn

--- a/lib/erga_web/controllers/project_controller.ex
+++ b/lib/erga_web/controllers/project_controller.ex
@@ -31,8 +31,19 @@ defmodule ErgaWeb.ProjectController do
   end
 
   def show(conn, %{"id" => id, "lang" => lang}) do
-    project = Research.get_project!(id)
-    render(conn, "show.html", project: project, lang: lang)
+    try do
+      project = Research.get_project!(id)
+      render(conn, "show.html", project: project, lang: lang)
+    rescue
+      _e in ArgumentError ->
+        case Research.get_project_code(id) do
+          {:ok, code} -> redirect(conn, to: Routes.project_path(conn, :show, code, lang: lang))
+          {:error, _e} ->
+            conn
+            |> put_flash(:error, "Project Code / ID not found.")
+            |> redirect(to: Routes.project_path(conn, :index))
+        end
+    end
   end
 
   def show(conn, %{"id" => id}) do

--- a/lib/erga_web/controllers/project_controller.ex
+++ b/lib/erga_web/controllers/project_controller.ex
@@ -31,19 +31,8 @@ defmodule ErgaWeb.ProjectController do
   end
 
   def show(conn, %{"id" => id, "lang" => lang}) do
-    try do
       project = Research.get_project!(id)
       render(conn, "show.html", project: project, lang: lang)
-    rescue
-      _e in ArgumentError ->
-        case Research.get_project_code(id) do
-          {:ok, code} -> redirect(conn, to: Routes.project_path(conn, :show, code, lang: lang))
-          {:error, _e} ->
-            conn
-            |> put_flash(:error, "Project Code / ID not found.")
-            |> redirect(to: Routes.project_path(conn, :index))
-        end
-    end
   end
 
   def show(conn, %{"id" => id}) do

--- a/lib/erga_web/controllers/project_controller.ex
+++ b/lib/erga_web/controllers/project_controller.ex
@@ -31,8 +31,15 @@ defmodule ErgaWeb.ProjectController do
   end
 
   def show(conn, %{"id" => id, "lang" => lang}) do
-      project = Research.get_project!(id)
-      render(conn, "show.html", project: project, lang: lang)
+      try do
+        project = Research.get_project!(id)
+        render(conn, "show.json", project: project, lang: lang)
+      rescue
+        _e in ArgumentError ->
+          conn
+          |> put_flash(:error, "Project ID not found.")
+          |> redirect(to: Routes.project_path(conn, :index))
+      end
   end
 
   def show(conn, %{"id" => id}) do

--- a/lib/erga_web/live/linked_resource_live/index.ex
+++ b/lib/erga_web/live/linked_resource_live/index.ex
@@ -5,7 +5,9 @@ defmodule ErgaWeb.LinkedResourceLive.Index do
   alias ErgaWeb.LinkedResourceView
   alias ErgaWeb.Router.Helpers, as: Routes
 
-  def render(assigns), do: LinkedResourceView.render("index.html", assigns)
+
+
+
 
   def mount(_params, _session, socket) do
     linked_resources = Research.list_linked_resources()
@@ -22,14 +24,38 @@ defmodule ErgaWeb.LinkedResourceLive.Index do
     {:ok, socket}
   end
 
+
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :delete, %{"id" => id, "project_id" => pid}) do
+    case delete_resource(id) do
+      {:ok, _} ->
+        socket
+        |> put_flash(:info, "Linked Resource deleted successfully.")
+        |> redirect(to: Routes.project_path(socket, :edit, pid))
+    end
+  end
+
+  def render(assigns) do
+    LinkedResourceView.render("index.html", assigns)
+  end
+
   def handle_event("delete_resource", %{"id" => id}, socket) do
+    case delete_resource(id) do
+      {:ok, _} ->
+        linked_resources = Research.list_linked_resources()
+        socket =
+          socket
+          |> assign(:linked_resources, linked_resources)
+        {:noreply, socket}
+    end
+  end
+
+  defp delete_resource(id) do
     resource = Research.get_linked_resource!(id)
-    {:ok, _resource} = Research.delete_linked_resource(resource)
-    linked_resources = Research.list_linked_resources()
-    socket =
-      socket
-      |> assign(:linked_resources, linked_resources)
-    {:noreply, socket}
+    Research.delete_linked_resource(resource)
   end
 
   def handle_event("load_resources", %{"foo" => params}, socket) do

--- a/lib/erga_web/router.ex
+++ b/lib/erga_web/router.ex
@@ -48,13 +48,14 @@ defmodule ErgaWeb.Router do
     live "/linked_resources", LinkedResourceLive.Index
     live "/linked_resources/:id", LinkedResourceLive.Show
     live "/linked_resources/:id/edit", LinkedResourceLive.Edit
+    live "/linked_resources/:id/delete", LinkedResourceLive.Index, :delete
 
 
     get("/external_links/new/:project_id", ExternalLinkController, :new)
     delete("/external_links/:id/:project_id", ExternalLinkController, :delete)
 
 
-                                         live "/persons", PersonLive.Index, :index
+    live "/persons", PersonLive.Index, :index
     live "/persons/new", PersonLive.Index, :new
     live "/persons/:id/edit", PersonLive.Index, :edit
 

--- a/lib/erga_web/templates/project/form_edit.html.eex
+++ b/lib/erga_web/templates/project/form_edit.html.eex
@@ -94,7 +94,7 @@
           <td><%= resource.linked_system %></td>
           <td><%= resource.linked_id %></td>
           <td> <%= link "edit", to: Routes.live_path(@conn, ErgaWeb.LinkedResourceLive.Edit, resource.id) %> |
-          <%= #link "remove", to: Routes.live_path(@conn, ErgaWeb.LinkedResourceLive.Index, resource), phx_click: "delete_resource", phx_value_id: resource.id, data: [confirm: "Are you sure?"] %></td>
+          <%= link "remove", to: Routes.linked_resource_index_path( @conn, :delete, resource.id, project_id: @project.id ), data: [confirm: "Are you sure?"] %></td>
       </tr>
       <% end %>
      </tbody>

--- a/lib/erga_web/views/api/project_view.ex
+++ b/lib/erga_web/views/api/project_view.ex
@@ -35,4 +35,13 @@ defmodule ErgaWeb.Api.ProjectView do
       image_count: Enum.count(project.images)
     }
   end
+
+  def render("error.json", err) do
+    %{
+      error: err.name,
+      msg: err.msg,
+      code: err.code
+     }
+  end
+
 end


### PR DESCRIPTION
Es sind eigentlich nur zwei kleine Änderungen, aber es arbeitet viel mit Error Handling und ist vielleicht nicht der Elixir-Weg, deshalb schaut es euch mal an.

Diese Änderung funktioniert nach einem Code-first Prinzip, zuerst wird versucht den Parameter als Code zu verwenden, wenn das scheitert, wird versucht den "Code" als ID zu benutzen und so den Code zu erhalten. Wenn das auch nicht geht, dann ist es offensichtlich weder Code noch ID. In diesem Fall wird man zum Index umgeleitet und es wird ein Fehler ausgegeben. 

Das hat den Vorteil das alte Routes mit der ID erhalten bleiben in der Browser URL aber immer die URL mit dem ProjectCode steht.

Ich habe jetzt mit einem richtigen und einem falschen Code getestet, sowie mit einer richtigen und einer falschen ID.  